### PR TITLE
Add `multiArgs` option for returning all arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ module.exports = (emitter, event, opts) => {
 
 	const ret = new Promise((resolve, reject) => {
 		opts = Object.assign({
-			rejectionEvents: ['error']
+			rejectionEvents: ['error'],
+			multiArgs: false
 		}, opts);
 
 		let addListener = emitter.on || emitter.addListener || emitter.addEventListener;
@@ -17,9 +18,13 @@ module.exports = (emitter, event, opts) => {
 		addListener = addListener.bind(emitter);
 		removeListener = removeListener.bind(emitter);
 
-		const resolveHandler = function(){
+		const resolveHandler = function(value){
 			cancel();
-			resolve(arguments);
+			if(opts.multiArgs){
+				resolve(arguments);
+			}else{
+				resolve(value);
+			}
 		};
 
 		const rejectHandler = reason => {

--- a/index.js
+++ b/index.js
@@ -27,9 +27,13 @@ module.exports = (emitter, event, opts) => {
 			}
 		};
 
-		const rejectHandler = reason => {
+		const rejectHandler = function(reason){
 			cancel();
-			reject(reason);
+			if(opts.multiArgs){
+				reject(arguments);
+			}else{
+				reject(reason);
+			}
 		};
 
 		cancel = () => {

--- a/index.js
+++ b/index.js
@@ -18,20 +18,20 @@ module.exports = (emitter, event, opts) => {
 		addListener = addListener.bind(emitter);
 		removeListener = removeListener.bind(emitter);
 
-		const resolveHandler = function(value){
+		const resolveHandler = function (value) {
 			cancel();
-			if(opts.multiArgs){
-				resolve(arguments);
-			}else{
+			if (opts.multiArgs) {
+				resolve([].slice.apply(arguments));
+			} else {
 				resolve(value);
 			}
 		};
 
-		const rejectHandler = function(reason){
+		const rejectHandler = function (reason) {
 			cancel();
-			if(opts.multiArgs){
-				reject(arguments);
-			}else{
+			if (opts.multiArgs) {
+				reject([].slice.apply(arguments));
+			} else {
 				reject(reason);
 			}
 		};

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ module.exports = (emitter, event, opts) => {
 		addListener = addListener.bind(emitter);
 		removeListener = removeListener.bind(emitter);
 
-		const resolveHandler = value => {
+		const resolveHandler = function(){
 			cancel();
-			resolve(value);
+			resolve(arguments);
 		};
 
 		const rejectHandler = reason => {

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,35 @@ Default: `['error']`
 
 Events that will reject the promise.
 
+##### multiArgs
+
+Type: `boolean`<br>
+Default: `false`
+
+By default, the promisified function will only return the second argument from the callback, which works fine for most APIs. This option can be useful for modules like `kue` that return multiple arguments. Turning this on will make it return an array of all arguments from the callback, excluding the error argument, instead of just the second argument. This also applies to rejections, where it returns an array of all the callback arguments, including the error.
+
+**ES7**
+```js
+import kue from 'kue';
+import pEvent from 'p-event';
+
+const queue = kue.createQueue();
+(async () => {
+	const [id, type] = await pEvent(queue, 'job enqueue', { multiArgs: true });
+})();
+```
+**ES6**
+
+```js
+const kue = require('kue');
+const pEvent = require('p-event');
+
+const queue = kue.createQueue();
+pEvent(queue, 'job enqueue', { multiArgs: true }).then(result => {
+	const [id, type] = result;
+});
+```
+
 
 ## Before and after
 

--- a/readme.md
+++ b/readme.md
@@ -78,26 +78,28 @@ Events that will reject the promise.
 Type: `boolean`<br>
 Default: `false`
 
-By default, the promisified function will only return the second argument from the callback, which works fine for most APIs. This option can be useful for modules like `kue` that return multiple arguments. Turning this on will make it return an array of all arguments from the callback, excluding the error argument, instead of just the second argument. This also applies to rejections, where it returns an array of all the callback arguments, including the error.
+By default, the promisified function will only return the first argument from the callback, which works fine for most APIs. This option can be useful for modules like `kue` that return multiple arguments. Turning this on will make it return an array of all arguments from the callback, instead of just the first argument. This also applies to rejections.
 
-**ES7**
+**ES2016**
+
 ```js
 import kue from 'kue';
 import pEvent from 'p-event';
 
 const queue = kue.createQueue();
 (async () => {
-	const [id, type] = await pEvent(queue, 'job enqueue', { multiArgs: true });
+	const [id, type] = await pEvent(queue, 'job enqueue', {multiArgs: true});
 })();
 ```
-**ES6**
+
+**ES2015**
 
 ```js
 const kue = require('kue');
 const pEvent = require('p-event');
 
 const queue = kue.createQueue();
-pEvent(queue, 'job enqueue', { multiArgs: true }).then(result => {
+pEvent(queue, 'job enqueue', {multiArgs: true}).then(result => {
 	const [id, type] = result;
 });
 ```

--- a/test.js
+++ b/test.js
@@ -35,6 +35,30 @@ test('`rejectionEvents` option', async t => {
 	}), '💩');
 });
 
+test('`multiArgs` option on resolve', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('🦄', '🌈', '🌈');
+	});
+
+	t.deepEqual(await m(emitter, '🦄', {
+		multiArgs: true
+	}), ['🌈', '🌈']);
+});
+
+test('`multiArgs` option on reject', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('error', '💩', '💩');
+	});
+
+	t.deepEqual(await m(emitter, 'error', {
+		multiArgs: true
+	}), ['💩', '💩']);
+});
+
 test('`.cancel()` method', t => {
 	const emitter = new EventEmitter();
 	const promise = m(emitter, '🦄');


### PR DESCRIPTION
Return arguments as data to resolved promise, because in some cases the event return multiple data through different arguments so we need to get it.