### PR TITLE
Add `filter` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 'use strict';
 const pTimeout = require('p-timeout');
+const isFunction = require('lodash.isfunction');
 
 module.exports = (emitter, event, opts) => {
 	let cancel;
 
 	const ret = new Promise((resolve, reject) => {
+		if (isFunction(opts)) {
+			opts = {filter: opts};
+		}
+
 		opts = Object.assign({
 			rejectionEvents: ['error'],
 			multiArgs: false
@@ -21,6 +26,16 @@ module.exports = (emitter, event, opts) => {
 		removeListener = removeListener.bind(emitter);
 
 		const resolveHandler = function (value) {
+			if (opts.filter) {
+				if (opts.multiArgs) {
+					if (!opts.filter([].slice.apply(arguments))) {
+						return;
+					}
+				} else if (!opts.filter(value)) {
+					return;
+				}
+			}
+
 			cancel();
 
 			if (opts.multiArgs) {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 'use strict';
 const pTimeout = require('p-timeout');
-const isFunction = require('lodash.isfunction');
 
 module.exports = (emitter, event, opts) => {
 	let cancel;
 
 	const ret = new Promise((resolve, reject) => {
-		if (isFunction(opts)) {
+		if (typeof opts === 'function') {
 			opts = {filter: opts};
 		}
 
@@ -26,14 +25,12 @@ module.exports = (emitter, event, opts) => {
 		removeListener = removeListener.bind(emitter);
 
 		const resolveHandler = function (value) {
-			if (opts.filter) {
-				if (opts.multiArgs) {
-					if (!opts.filter([].slice.apply(arguments))) {
-						return;
-					}
-				} else if (!opts.filter(value)) {
-					return;
-				}
+			if (opts.multiArgs) {
+				value = [].slice.apply(arguments);
+			}
+
+			if (opts.filter && !opts.filter(value)) {
+				return;
 			}
 
 			cancel();

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-timeout": "^1.1.1",
-    "lodash.isfunction": "^3.0.8"
+    "p-timeout": "^1.1.1"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-timeout": "^1.1.1"
+    "p-timeout": "^1.1.1",
+    "lodash.isfunction": "^3.0.8"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,23 @@ Default: `Infinity`
 Time in milliseconds before timing out.
 
 
+##### filter
+
+Type: `Function`<br>
+Default: None
+
+Filter function for accepting an event.
+
+```js
+const pEvent = require('p-event');
+const emitter = require('./some-event-emitter');
+
+pEvent(emitter, '🦄', e => e >= 3).then(result => {
+	// do something with first 🦄 event with value greater than or equal to 3
+});
+```
+
+
 ## Before and after
 
 ```js

--- a/test.js
+++ b/test.js
@@ -120,3 +120,76 @@ test('`timeout` option resolves when long enough', async t => {
 		timeout: 250
 	}), '🌈');
 });
+
+test('filter function to match event', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('🦄', 1);
+		emitter.emit('🦄', 2);
+		emitter.emit('🦄', 4);
+		emitter.emit('🦄', 3);
+	});
+
+	t.is(await m(emitter, '🦄', e => e >= 3), 4);
+});
+
+test('filter option to match event', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('🦄', 1);
+		emitter.emit('🦄', 2);
+		emitter.emit('🦄', 4);
+		emitter.emit('🦄', 3);
+	});
+
+	t.is(await m(emitter, '🦄', {filter: e => e >= 3}), 4);
+});
+
+test('filter option caught with error', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('🦄', 1);
+		emitter.emit('🦄', 2);
+		emitter.emit('error', new Error('💩'));
+		emitter.emit('🦄', 4);
+		emitter.emit('🦄', 3);
+	});
+
+	await t.throws(m(emitter, '🦄', {filter: e => e >= 3}), '💩');
+});
+
+test('filter option to match event with multiArgs', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('🦄', 1, 1);
+		emitter.emit('🦄', 2, 2);
+		emitter.emit('🦄', 4, 3);
+		emitter.emit('🦄', 3, 4);
+	});
+
+	t.deepEqual(await m(emitter, '🦄', {
+		filter: es => es[0] >= 3 && es[1] >= es[0],
+		multiArgs: true
+	}), [3, 4]);
+});
+
+test('filter option returned with multiArgs', async t => {
+	const emitter = new EventEmitter();
+
+	delay(200).then(() => {
+		emitter.emit('🦄', 1, 1);
+		emitter.emit('🦄', 2, 2);
+		emitter.emit('error', 10000, '💩');
+		emitter.emit('🦄', 4, 3);
+		emitter.emit('🦄', 3, 4);
+	});
+
+	t.deepEqual(await m(emitter, 'error', {
+		filter: es => (es[0] > 9999) && (es[1] === '💩'),
+		multiArgs: true
+	}), [10000, '💩']);
+});


### PR DESCRIPTION
Added pattern matching as discussed in https://github.com/sindresorhus/p-event/issues/5.

I added an overload for filter function or option since the referred examples and my use cases did not need any of the other options.

I ensured it worked with multiArgs and error cases, but am not sure if there needs to be more combinations tested. Let me know!

---

Fixes #5 