### PR TITLE
Add `.cancel()` method to `p-timeout`

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,17 +62,21 @@ module.exports = (emitter, event, opts) => {
 		}
 	});
 
-	ret.cancel = cancel;
-
 	if (typeof opts.timeout === 'number') {
-		return pTimeout(ret, opts.timeout).catch(err => {
+		const timeout = pTimeout(ret, opts.timeout).catch(err => {
 			if (err instanceof pTimeout.TimeoutError) {
 				cancel();
 			}
 
 			throw err;
 		});
+
+		timeout.cancel = cancel;
+
+		return timeout;
 	}
+
+	ret.cancel = cancel;
 
 	return ret;
 };

--- a/test.js
+++ b/test.js
@@ -67,6 +67,14 @@ test('`.cancel()` method', t => {
 	t.is(emitter.listenerCount('🦄'), 0);
 });
 
+test('`.cancel()` method with `timeout` option', t => {
+	const emitter = new EventEmitter();
+	const promise = m(emitter, '🦄', {timeout: 250});
+	t.is(emitter.listenerCount('🦄'), 1);
+	promise.cancel();
+	t.is(emitter.listenerCount('🦄'), 0);
+});
+
 test('error on incompatible emitter', async t => {
 	await t.throws(m({}, '🦄'), /not compatible/);
 });


### PR DESCRIPTION
As pointed out in #7, the `.cancel()` method wasn't added to the promise wrapped in `pTimeout`.

Fixes #7.