### PR TITLE
Update p-timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,13 +65,11 @@ module.exports = (emitter, event, opts) => {
 	ret.cancel = cancel;
 
 	if (typeof opts.timeout === 'number') {
-		return pTimeout(ret, opts.timeout).catch(err => {
-			if (err instanceof pTimeout.TimeoutError) {
-				cancel();
-			}
+		const timeout = pTimeout(ret, opts.timeout);
 
-			throw err;
-		});
+		timeout.cancel = cancel;
+
+		return timeout;
 	}
 
 	return ret;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-timeout": "^1.1.1"
+    "p-timeout": "^2.0.1"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -67,6 +67,14 @@ test('`.cancel()` method', t => {
 	t.is(emitter.listenerCount('🦄'), 0);
 });
 
+test('`.cancel()` method with `timeout` option', t => {
+	const emitter = new EventEmitter();
+	const promise = m(emitter, '🦄', {timeout: 250});
+	t.is(emitter.listenerCount('🦄'), 1);
+	promise.cancel();
+	t.is(emitter.listenerCount('🦄'), 0);
+});
+
 test('error on incompatible emitter', async t => {
 	await t.throws(m({}, '🦄'), /not compatible/);
 });


### PR DESCRIPTION
Avoid needing two versions of p-timeout when using latest p-event and got.