### PR TITLE
Document dealing with emitters that can resolve with success

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ const emitter = require('./some-event-emitter');
 
 (async () => {
 	try {
-		await pEvent(emitter, 'finish');
+		const result = await pEvent(emitter, 'finish');
 
 		// `emitter` emitted a `finish` event
 		console.log(result);
@@ -169,6 +169,51 @@ async function getOpenReadStream(file) {
 })().catch(console.error);
 ```
 
+
+## Dealing with calls that resolve with an error code
+
+Some functions might use a single event for success and for certain errors.  Promises
+make this easy to have combined error handler for both error events and successes
+containing values which represent errors.
+
+```js
+const pEvent = require('p-event');
+const emitter = require('./some-event-emitter');
+
+(async () => {
+	try {
+		const result = await pEvent(emitter, 'finish');
+
+		if (result === 'unwanted result') {
+			throw new Error('Emitter finished with an error');
+		}
+		// `emitter` emitted a `finish` event with an acceptible value
+		console.log(result);
+	} catch (error) {
+		// `emitter` emitted an `error` event or emitted
+		// a `finish` with 'unwanted result'
+		console.error(error);
+	}
+})();
+```
+
+This also works while using `.then()`.
+
+```js
+	pEvent(emitter, 'finish')
+		.then(result => {
+			if (result === 'unwanted result') {
+				throw new Error('Emitter finished with an error');
+			}
+			// `emitter` emitted a `finish` event with an acceptible value
+			console.log(result);
+		})
+		.catch(error => {
+			// `emitter` emitted an `error` event or emitted
+			// a `finish` with 'unwanted result'
+			console.error(error);
+		});
+```
 
 ## Related
 


### PR DESCRIPTION
This allows certain values to be treated as an error.  An example
use case is `child_process.spawn` where the `exit` event only indicates
that the child process was successfully executed, but a non-zero code
is still an error.