### PR TITLE
Add `limit` option to `pEvent.iterator()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,6 @@ Default: `Infinity`
 
 Time in milliseconds before timing out.
 
-
 ##### filter
 
 Type: `Function`
@@ -213,6 +212,13 @@ This method has the same arguments and options as `pEvent()` with the addition o
 #### options
 
 Type: `Object`
+
+##### limit
+
+Type: `number` *(non-negative integer)*<br>
+Default: `Infinity`
+
+Maximum number of events for the iterator before it ends. When the limit is reached, the iterator will be marked as `done`. This option is useful to paginate events, for example, fetching 10 events per page.
 
 ##### resolutionEvents
 


### PR DESCRIPTION
This PR adds `options.limit` support so that the `iterator` can configure the maximum number of events to be received. It's useful for pulling in a limited number of events.