### PR TITLE
Add support for multiple event names

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const normalizeEmitter = emitter => {
 	};
 };
 
+const normalizeEvents = event => Array.isArray(event) ? event : [event];
+
 const multiple = (emitter, event, options) => {
 	let cancel;
 	const ret = new Promise((resolve, reject) => {
@@ -29,6 +31,9 @@ const multiple = (emitter, event, options) => {
 		if (!(options.count >= 0 && (options.count === Infinity || Number.isInteger(options.count)))) {
 			throw new TypeError('The `count` option should be at least 0 or more');
 		}
+
+		// Allow multiple events
+		const events = normalizeEvents(event);
 
 		const items = [];
 		const {addListener, removeListener} = normalizeEmitter(emitter);
@@ -54,14 +59,18 @@ const multiple = (emitter, event, options) => {
 		};
 
 		cancel = () => {
-			removeListener(event, onItem);
+			for (const event of events) {
+				removeListener(event, onItem);
+			}
 
 			for (const rejectionEvent of options.rejectionEvents) {
 				removeListener(rejectionEvent, rejectHandler);
 			}
 		};
 
-		addListener(event, onItem);
+		for (const event of events) {
+			addListener(event, onItem);
+		}
 
 		for (const rejectionEvent of options.rejectionEvents) {
 			addListener(rejectionEvent, rejectHandler);
@@ -108,6 +117,9 @@ module.exports.iterator = (emitter, event, options) => {
 		options = {filter: options};
 	}
 
+	// Allow multiple events
+	const events = normalizeEvents(event);
+
 	options = Object.assign({
 		rejectionEvents: ['error'],
 		resolutionEvents: [],
@@ -135,7 +147,9 @@ module.exports.iterator = (emitter, event, options) => {
 
 	const cancel = () => {
 		done = true;
-		removeListener(event, valueHandler);
+		for (const event of events) {
+			removeListener(event, valueHandler);
+		}
 
 		for (const rejectionEvent of options.rejectionEvents) {
 			removeListener(rejectionEvent, rejectHandler);
@@ -181,7 +195,9 @@ module.exports.iterator = (emitter, event, options) => {
 		cancel();
 	};
 
-	addListener(event, valueHandler);
+	for (const event of events) {
+		addListener(event, valueHandler);
+	}
 
 	for (const rejectionEvent of options.rejectionEvents) {
 		addListener(rejectionEvent, rejectHandler);

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,9 @@ const emitter = require('./some-event-emitter');
 
 Returns a `Promise` that is fulfilled when `emitter` emits an event matching `event`, or rejects if `emitter` emits any of the events defined in the `rejectionEvents` option.
 
+**Note**: `event` is a string for a single event type, for example, `'data'`. To listen on multiple
+events, pass an array of strings, such as `['started', 'stopped']`.
+
 The returned promise has a `.cancel()` method, which when called, removes the event listeners and causes the promise to never be settled.
 
 #### emitter
@@ -85,9 +88,9 @@ Should have either a `.on()`/`.addListener()`/`.addEventListener()` and `.off()`
 
 #### event
 
-Type: `string`
+Type: `string` or `string[]`
 
-Name of the event to listen to.
+Name(s) of the event to listen to.
 
 If the same event is defined both here and in `rejectionEvents`, this one takes priority.
 

--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,9 @@ Should have either a `.on()`/`.addListener()`/`.addEventListener()` and `.off()`
 
 #### event
 
-Type: `string` or `string[]`
+Type: `string | string[]`
 
-Name(s) of the event to listen to.
+Name of the event or events to listen to.
 
 If the same event is defined both here and in `rejectionEvents`, this one takes priority.
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,22 @@ test('event to promise', async t => {
 	t.is(await pEvent(emitter, '🦄'), '🌈');
 });
 
+test('event to promise with multiple event names', async t => {
+	const emitter = new EventEmitter();
+
+	delay(100).then(() => {
+		emitter.emit('🦄', '🌈');
+	});
+
+	t.is(await pEvent(emitter, ['🦄', '🌈']), '🌈');
+
+	delay(100).then(() => {
+		emitter.emit('🌈', '🦄');
+	});
+
+	t.is(await pEvent(emitter, ['🦄', '🌈']), '🦄');
+});
+
 test('error event rejects the promise', async t => {
 	const emitter = new EventEmitter();
 
@@ -227,6 +243,25 @@ test('event to AsyncIterator', async t => {
 	t.deepEqual(await iterator.next(), {done: false, value: 'Some third thing.'});
 });
 
+test('event to AsyncIterator with multiple event names', async t => {
+	const emitter = new EventEmitter();
+	const iterator = pEvent.iterator(emitter, ['🦄', '🌈']);
+
+	delay(50).then(() => {
+		emitter.emit('🦄', '🌈');
+	});
+	delay(100).then(() => {
+		emitter.emit('🌈', 'Something else.');
+	});
+	delay(150).then(() => {
+		emitter.emit('🦄', 'Some third thing.');
+	});
+
+	t.deepEqual(await iterator.next(), {done: false, value: '🌈'});
+	t.deepEqual(await iterator.next(), {done: false, value: 'Something else.'});
+	t.deepEqual(await iterator.next(), {done: false, value: 'Some third thing.'});
+});
+
 test('event to AsyncIterator (backpressure)', async t => {
 	const emitter = new EventEmitter();
 	const iterator = pEvent.iterator(emitter, '🦄');
@@ -276,6 +311,21 @@ test('.multiple()', async t => {
 	emitter.emit('🌂', '🌞');
 
 	t.deepEqual(await promise, ['🌞', '🌞', '🌞']);
+});
+
+test('.multiple() with an array of event names', async t => {
+	const emitter = new EventEmitter();
+
+	const promise = pEvent.multiple(emitter, ['🌂', '🌞'], {
+		count: 3
+	});
+
+	emitter.emit('🌂', '🌞');
+	emitter.emit('🌞', '🌂');
+	emitter.emit('🌞', '🌂');
+	emitter.emit('🌂', '🌞');
+
+	t.deepEqual(await promise, ['🌞', '🌂', '🌂']);
 });
 
 test('.multiple() - `resolveImmediately` option', async t => {


### PR DESCRIPTION
This change extends `event` to allow an array so that promises can be backed by listening on multiple event types.