### PR TITLE
Make `.iterator()` implement `return()` correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ module.exports.iterator = (emitter, event, options) => {
 		},
 		return(value) {
 			cancel();
-			return {done, value};
+			return Promise.resolve({done, value});
 		}
 	};
 };

--- a/test.js
+++ b/test.js
@@ -243,6 +243,15 @@ test('event to AsyncIterator', async t => {
 	t.deepEqual(await iterator.next(), {done: false, value: 'Some third thing.'});
 });
 
+test('event to AsyncIterator implements return', async t => {
+	const emitter = new EventEmitter();
+	const iterator = pEvent.iterator(emitter, '🦄');
+
+	t.true(iterator.return('x') instanceof Promise);
+	t.deepEqual(await iterator.return('y'), {done: true, value: 'y'});
+	t.deepEqual(await iterator.next(), {done: true, value: undefined});
+});
+
 test('event to AsyncIterator with multiple event names', async t => {
 	const emitter = new EventEmitter();
 	const iterator = pEvent.iterator(emitter, ['🦄', '🌈']);


### PR DESCRIPTION
Please note the current implementation of `return()` breaks the AsyncIterator interface. It should return a promise.

```ts
interface AsyncIterator<T> {
    next(value?: any): Promise<IteratorResult<T>>;
    return?(value?: any): Promise<IteratorResult<T>>;
    throw?(e?: any): Promise<IteratorResult<T>>;
}
```