### PR TITLE
Tighten up `multiArgs` TypeScript type constraints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 /// <reference lib="esnext"/>
 
-export type AddRemoveListener<Args extends any[]> = (
+export type AddRemoveListener<Arguments extends unknown[]> = (
 	event: string | symbol,
 	listener: (
-		...args: Args,
+		...args: Arguments,
 	) => void
 ) => void;
 
-export interface Emitter<EmittedType extends any[]> {
+export interface Emitter<EmittedType extends unknown[]> {
 	on?: AddRemoveListener<EmittedType>;
 	addListener?: AddRemoveListener<EmittedType>;
 	addEventListener?: AddRemoveListener<EmittedType>;
@@ -16,7 +16,7 @@ export interface Emitter<EmittedType extends any[]> {
 	removeEventListener?: AddRemoveListener<EmittedType>;
 }
 
-export type FilterFunction<ElementType extends any[]> = (... args: ElementType) => boolean;
+export type FilterFunction<ElementType extends unknown[]> = (...args: ElementType) => boolean;
 
 export interface CancelablePromise<ResolveType> extends Promise<ResolveType> {
 	cancel(): void;
@@ -29,7 +29,7 @@ export interface CancelablePromise<ResolveType> extends Promise<ResolveType> {
  * @param event - Name of the event or events to listen to. If the same event is defined both here and in `rejectionEvents`, this one takes priority. **Note**: `event` is a string for a single event type, for example, `'data'`. To listen on multiple events, pass an array of strings, such as `['started', 'stopped']`.
  * @returns A `Promise` that is fulfilled when emitter emits an event matching `event`, or rejects if emitter emits any of the events defined in the `rejectionEvents` option. The returned promise has a `.cancel()` method, which when called, removes the event listeners and causes the promise to never be settled.
  */
-declare function pEvent<EmittedType extends any[]>(
+declare function pEvent<EmittedType extends unknown[]>(
 	emitter: Emitter<EmittedType>,
 	event: string | symbol | (string | symbol)[],
 	options: MultiArgumentsOptions<EmittedType>
@@ -50,7 +50,7 @@ export default pEvent;
 /**
  * Wait for multiple event emissions. Returns an array.
  */
-export function multiple<EmittedType extends any[]>(
+export function multiple<EmittedType extends unknown[]>(
 	emitter: Emitter<EmittedType>,
 	event: string | symbol | (string | symbol)[],
 	options: MultipleMultiArgumentsOptions<EmittedType>
@@ -64,7 +64,7 @@ export function multiple<EmittedType>(
 /**
  * @returns An [async iterator](http://2ality.com/2016/10/asynchronous-iteration.html) that lets you asynchronously iterate over events of `event` emitted from `emitter`. The iterator ends when `emitter` emits an event matching any of the events defined in `resolutionEvents`, or rejects if `emitter` emits any of the events defined in the `rejectionEvents` option.
  */
-export function iterator<EmittedType extends any[]>(
+export function iterator<EmittedType extends unknown[]>(
 	emitter: Emitter<EmittedType>,
 	event: string | symbol | (string | symbol)[],
 	options: IteratorMultiArgumentsOptions<EmittedType>
@@ -80,7 +80,7 @@ export function iterator<EmittedType>(
 	options?: IteratorOptions<[EmittedType]>
 ): AsyncIterableIterator<EmittedType>;
 
-export interface Options<EmittedType extends any[]> {
+export interface Options<EmittedType extends unknown[]> {
 	/**
 	 * Events that will reject the promise.
 	 *
@@ -127,11 +127,11 @@ export interface Options<EmittedType extends any[]> {
 	readonly filter?: FilterFunction<EmittedType>;
 }
 
-export interface MultiArgumentsOptions<EmittedType extends any[]> extends Options<EmittedType> {
+export interface MultiArgumentsOptions<EmittedType extends unknown[]> extends Options<EmittedType> {
 	readonly multiArgs: true;
 }
 
-export interface MultipleOptions<EmittedType extends any[]> extends Options<EmittedType> {
+export interface MultipleOptions<EmittedType extends unknown[]> extends Options<EmittedType> {
 	/**
 	 * The number of times the event needs to be emitted before the promise resolves.
 	 */
@@ -173,11 +173,11 @@ export interface MultipleOptions<EmittedType extends any[]> extends Options<Emit
 	readonly resolveImmediately?: boolean;
 }
 
-export interface MultipleMultiArgumentsOptions<EmittedType extends any[]> extends MultipleOptions<EmittedType> {
+export interface MultipleMultiArgumentsOptions<EmittedType extends unknown[]> extends MultipleOptions<EmittedType> {
 	readonly multiArgs: true;
 }
 
-export interface IteratorOptions<EmittedType extends any[]> extends Options<EmittedType> {
+export interface IteratorOptions<EmittedType extends unknown[]> extends Options<EmittedType> {
 	/**
 	 * Maximum number of events for the iterator before it ends. When the limit is reached, the iterator will be marked as `done`. This option is useful to paginate events, for example, fetching 10 events per page.
 	 *
@@ -193,7 +193,7 @@ export interface IteratorOptions<EmittedType extends any[]> extends Options<Emit
 	resolutionEvents?: (string | symbol)[];
 }
 
-export interface IteratorMultiArgumentsOptions<EmittedType extends any[]>
+export interface IteratorMultiArgumentsOptions<EmittedType extends unknown[]>
 	extends IteratorOptions<EmittedType> {
 	multiArgs: true;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,22 @@
 /// <reference lib="esnext"/>
 
-export type AddRemoveListener<FirstArgumentType, RestArgumentsType> = (
+export type AddRemoveListener<Args extends any[]> = (
 	event: string | symbol,
 	listener: (
-		firstArgument: FirstArgumentType,
-		...rest: RestArgumentsType[]
+		...args: Args,
 	) => void
 ) => void;
 
-export interface Emitter<EmittedType, EmittedTypeRest> {
-	on?: AddRemoveListener<EmittedType, EmittedTypeRest>;
-	addListener?: AddRemoveListener<EmittedType, EmittedTypeRest>;
-	addEventListener?: AddRemoveListener<EmittedType, EmittedTypeRest>;
-	off?: AddRemoveListener<EmittedType, EmittedTypeRest>;
-	removeListener?: AddRemoveListener<EmittedType, EmittedTypeRest>;
-	removeEventListener?: AddRemoveListener<EmittedType, EmittedTypeRest>;
+export interface Emitter<EmittedType extends any[]> {
+	on?: AddRemoveListener<EmittedType>;
+	addListener?: AddRemoveListener<EmittedType>;
+	addEventListener?: AddRemoveListener<EmittedType>;
+	off?: AddRemoveListener<EmittedType>;
+	removeListener?: AddRemoveListener<EmittedType>;
+	removeEventListener?: AddRemoveListener<EmittedType>;
 }
 
-export type FilterFunction<ElementType> = (element: ElementType) => boolean;
+export type FilterFunction<ElementType extends any[]> = (... args: ElementType) => boolean;
 
 export interface CancelablePromise<ResolveType> extends Promise<ResolveType> {
 	cancel(): void;
@@ -30,20 +29,20 @@ export interface CancelablePromise<ResolveType> extends Promise<ResolveType> {
  * @param event - Name of the event or events to listen to. If the same event is defined both here and in `rejectionEvents`, this one takes priority. **Note**: `event` is a string for a single event type, for example, `'data'`. To listen on multiple events, pass an array of strings, such as `['started', 'stopped']`.
  * @returns A `Promise` that is fulfilled when emitter emits an event matching `event`, or rejects if emitter emits any of the events defined in the `rejectionEvents` option. The returned promise has a `.cancel()` method, which when called, removes the event listeners and causes the promise to never be settled.
  */
-declare function pEvent<EmittedType, EmittedTypeRest = EmittedType>(
-	emitter: Emitter<EmittedType, EmittedTypeRest>,
+declare function pEvent<EmittedType extends any[]>(
+	emitter: Emitter<EmittedType>,
 	event: string | symbol | (string | symbol)[],
-	options: MultiArgumentsOptions<EmittedType | EmittedTypeRest>
-): CancelablePromise<(EmittedType | EmittedTypeRest)[]>;
-declare function pEvent<EmittedType>(
-	emitter: Emitter<EmittedType, unknown>,
-	event: string | symbol | (string | symbol)[],
-	filter: FilterFunction<EmittedType>
+	options: MultiArgumentsOptions<EmittedType>
 ): CancelablePromise<EmittedType>;
 declare function pEvent<EmittedType>(
-	emitter: Emitter<EmittedType, unknown>,
+	emitter: Emitter<[EmittedType]>,
 	event: string | symbol | (string | symbol)[],
-	options?: Options<EmittedType>
+	filter: FilterFunction<[EmittedType]>
+): CancelablePromise<EmittedType>;
+declare function pEvent<EmittedType>(
+	emitter: Emitter<[EmittedType]>,
+	event: string | symbol | (string | symbol)[],
+	options?: Options<[EmittedType]>
 ): CancelablePromise<EmittedType>;
 
 export default pEvent;
@@ -51,37 +50,37 @@ export default pEvent;
 /**
  * Wait for multiple event emissions. Returns an array.
  */
-export function multiple<EmittedType, EmittedTypeRest = EmittedType>(
-	emitter: Emitter<EmittedType, EmittedTypeRest>,
+export function multiple<EmittedType extends any[]>(
+	emitter: Emitter<EmittedType>,
 	event: string | symbol | (string | symbol)[],
-	options: MultipleMultiArgumentsOptions<EmittedType | EmittedTypeRest>
-): CancelablePromise<(EmittedType | EmittedTypeRest)[][]>;
+	options: MultipleMultiArgumentsOptions<EmittedType>
+): CancelablePromise<EmittedType[]>;
 export function multiple<EmittedType>(
-	emitter: Emitter<EmittedType, unknown>,
+	emitter: Emitter<[EmittedType]>,
 	event: string | symbol | (string | symbol)[],
-	options: MultipleOptions<EmittedType>
+	options: MultipleOptions<[EmittedType]>
 ): CancelablePromise<EmittedType[]>;
 
 /**
  * @returns An [async iterator](http://2ality.com/2016/10/asynchronous-iteration.html) that lets you asynchronously iterate over events of `event` emitted from `emitter`. The iterator ends when `emitter` emits an event matching any of the events defined in `resolutionEvents`, or rejects if `emitter` emits any of the events defined in the `rejectionEvents` option.
  */
-export function iterator<EmittedType, EmittedTypeRest = EmittedType>(
-	emitter: Emitter<EmittedType, EmittedTypeRest>,
+export function iterator<EmittedType extends any[]>(
+	emitter: Emitter<EmittedType>,
 	event: string | symbol | (string | symbol)[],
-	options: IteratorMultiArgumentsOptions<EmittedType | EmittedTypeRest>
-): AsyncIterableIterator<(EmittedType | EmittedTypeRest)[]>;
-export function iterator<EmittedType>(
-	emitter: Emitter<EmittedType, unknown>,
-	event: string | symbol | (string | symbol)[],
-	filter: FilterFunction<EmittedType>
+	options: IteratorMultiArgumentsOptions<EmittedType>
 ): AsyncIterableIterator<EmittedType>;
 export function iterator<EmittedType>(
-	emitter: Emitter<EmittedType, unknown>,
+	emitter: Emitter<[EmittedType]>,
 	event: string | symbol | (string | symbol)[],
-	options?: IteratorOptions<EmittedType>
+	filter: FilterFunction<[EmittedType]>
+): AsyncIterableIterator<EmittedType>;
+export function iterator<EmittedType>(
+	emitter: Emitter<[EmittedType]>,
+	event: string | symbol | (string | symbol)[],
+	options?: IteratorOptions<[EmittedType]>
 ): AsyncIterableIterator<EmittedType>;
 
-export interface Options<EmittedType> {
+export interface Options<EmittedType extends any[]> {
 	/**
 	 * Events that will reject the promise.
 	 *
@@ -128,11 +127,11 @@ export interface Options<EmittedType> {
 	readonly filter?: FilterFunction<EmittedType>;
 }
 
-export interface MultiArgumentsOptions<EmittedType> extends Options<EmittedType> {
+export interface MultiArgumentsOptions<EmittedType extends any[]> extends Options<EmittedType> {
 	readonly multiArgs: true;
 }
 
-export interface MultipleOptions<EmittedType> extends Options<EmittedType> {
+export interface MultipleOptions<EmittedType extends any[]> extends Options<EmittedType> {
 	/**
 	 * The number of times the event needs to be emitted before the promise resolves.
 	 */
@@ -174,11 +173,11 @@ export interface MultipleOptions<EmittedType> extends Options<EmittedType> {
 	readonly resolveImmediately?: boolean;
 }
 
-export interface MultipleMultiArgumentsOptions<EmittedType> extends MultipleOptions<EmittedType> {
+export interface MultipleMultiArgumentsOptions<EmittedType extends any[]> extends MultipleOptions<EmittedType> {
 	readonly multiArgs: true;
 }
 
-export interface IteratorOptions<EmittedType> extends Options<EmittedType> {
+export interface IteratorOptions<EmittedType extends any[]> extends Options<EmittedType> {
 	/**
 	 * Maximum number of events for the iterator before it ends. When the limit is reached, the iterator will be marked as `done`. This option is useful to paginate events, for example, fetching 10 events per page.
 	 *
@@ -194,7 +193,7 @@ export interface IteratorOptions<EmittedType> extends Options<EmittedType> {
 	resolutionEvents?: (string | symbol)[];
 }
 
-export interface IteratorMultiArgumentsOptions<EmittedType>
+export interface IteratorMultiArgumentsOptions<EmittedType extends any[]>
 	extends IteratorOptions<EmittedType> {
 	multiArgs: true;
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -75,7 +75,7 @@ expectType<CancelablePromise<number>>(
 expectType<CancelablePromise<number>>(
 	pEvent(new NodeEmitter(), 'finish', {filter: value => value > 3})
 );
-expectType<CancelablePromise<(string | number)[]>>(
+expectType<CancelablePromise<[number, string]>>(
 	pEvent(new NodeEmitter(), 'finish', {multiArgs: true})
 );
 
@@ -90,7 +90,7 @@ expectType<CancelablePromise<number[]>>(
 		count: Infinity
 	})
 );
-expectType<CancelablePromise<(string | number)[][]>>(
+expectType<CancelablePromise<[number, string][]>>(
 	multiple(new NodeEmitter(), 'hello', {
 		count: Infinity,
 		multiArgs: true
@@ -110,7 +110,7 @@ expectType<AsyncIterableIterator<number>>(
 expectType<AsyncIterableIterator<number>>(
 	iterator(new NodeEmitter(), 'finish', {resolutionEvents: ['finish']})
 );
-expectType<AsyncIterableIterator<(string | number)[]>>(
+expectType<AsyncIterableIterator<[number, string]>>(
 	iterator(new NodeEmitter(), 'finish', {multiArgs: true})
 );
 


### PR DESCRIPTION
This PR modifies the type constraints by using rest elements/spread types by default, and treating the single-argument (non-multiArgs) case as special by passing it to `Emitter` as `[EmittedType]` (note the brackets, making it a single element tuple).

This provides better ergonomics on iterator, e.g.: this case with Express:

```ts
      const testRouteIterator = pEvent.iterator<[Request, Response]>(app as any, 'test', {
        multiArgs: true,
      });

      for await (const callback of testRouteIterator) { // callback: [Request, Response]
        const [req, res]: [Request, Response] = callback;
      }
```

![image](https://user-images.githubusercontent.com/788800/54257312-272a5f80-451c-11e9-9da5-ca984749642d.png)


# Comparison

Relative to what version 3.0 emits for types:

## Using `iterator<[Request, Response]>`

```ts
      const testRouteIterator = pEvent.iterator<[Request, Response]>(app as any, 'test', {
        multiArgs: true,
      });

      for await (const callback of testRouteIterator) { // callback: [Request, Response][]
        const [req, res]: [Request, Response] = callback;
      }
```
![image](https://user-images.githubusercontent.com/788800/54257433-88523300-451c-11e9-906a-9964bc3bb222.png)


This doesn't make sense, because it's not an array of [Request, Response] tuples.


## Using `iterator<Request, [Response]>`


```ts
      const testRouteIterator = pEvent.iterator<Request, [Response]>(app as any, 'test', {
        multiArgs: true,
      });

      for await (const callback of testRouteIterator) { // callback: (Request | [Response])[]
        const [req, res]: [Request, Response] = callback;
      }
```
![image](https://user-images.githubusercontent.com/788800/54257531-dff09e80-451c-11e9-912b-ed9ee12adb47.png)


This doesn't make sense because the first argument is *never* a `Response`, and the second argument is *never* a `Request`, but indeed, this type checks, but it cannot possibly be true:

```ts
      for await (const callback of testRouteIterator) { // callback: (Request | [Response])[]
        const arg0: Request | [Response] = callback[0];
        const arg1: Request | [Response] = callback[1];
        const arg2: Request | [Response] = callback[2];
        const arg3: Request | [Response] = callback[3];
        const arg4: Request | [Response] = callback[4];
      }
```