### PR TITLE
Include all rejection arguments with `multiArgs`

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,9 @@ const multiple = (emitter, event, options) => {
 			}
 		};
 
-		const rejectHandler = error => {
+		const rejectHandler = (...args) => {
 			cancel();
-			reject(error);
+			reject(options.multiArgs ? args : args[0]);
 		};
 
 		cancel = () => {

--- a/test.js
+++ b/test.js
@@ -82,6 +82,24 @@ test('`multiArgs` option on reject', async t => {
 	}), ['💩', '💩']);
 });
 
+test(' `multiArgs` and `rejectionEvents` options on reject', async t => {
+	const emitter = new EventEmitter();
+
+	(async () => {
+		await delay(200);
+		emitter.emit('error', '💩', '💩');
+	})();
+
+	try {
+		await pEvent(emitter, '🦄', {
+			multiArgs: true,
+			rejectionEvents: ['error']
+		});
+	} catch (error) {
+		t.deepEqual(error, ['💩', '💩']);
+	}
+});
+
 test('`.cancel()` method', t => {
 	const emitter = new EventEmitter();
 	const promise = pEvent(emitter, '🦄');


### PR DESCRIPTION
When using both `multiArgs` and `rejectionEvents` if a rejection event is emitted with multiple arguments we should reject with all those arguments.

It's quite an uncommon case as error events are usually emitted with one argument, however there is some API out there that emit error events with multiple args.

This fix a regression that was introduced here: https://github.com/sindresorhus/p-event/commit/b902979ac0a7e3ec8f4266033c4cb4560711cc1b#diff-168726dbe96b3ce427e7fedce31bb0bcL46-R53