### PR TITLE
Expose `TimeoutError`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,13 @@
 /// <reference lib="esnext"/>
 
+declare class TimeoutErrorClass extends Error {
+	readonly name: 'TimeoutError';
+	constructor(message?: string);
+}
+
 declare namespace pEvent {
+	type TimeoutError = TimeoutErrorClass;
+
 	type AddRemoveListener<EventName extends string | symbol, Arguments extends unknown[]> = (
 		event: EventName,
 		listener: (...arguments: Arguments) => void
@@ -251,6 +258,8 @@ declare const pEvent: {
 
 	// TODO: Remove this for the next major release
 	default: typeof pEvent;
+
+	TimeoutError: typeof TimeoutErrorClass;
 };
 
 export = pEvent;

--- a/index.js
+++ b/index.js
@@ -287,3 +287,5 @@ module.exports.iterator = (emitter, event, options) => {
 		}
 	};
 };
+
+module.exports.TimeoutError = pTimeout.TimeoutError;

--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,24 @@ Default: `[]`
 
 Events that will end the iterator.
 
+### pEvent.TimeoutError
+
+Exposed for instance checking and sub-classing.
+
+Example:
+
+```js
+const pEvent = require('p-event');
+
+try {
+	await pEvent(emitter, 'finish');
+} catch (error) {
+	if (error instanceof pEvent.TimeoutError) {
+		// Do something specific for timeout errors
+	}
+}
+```
+
 ## Before and after
 
 ```js


### PR DESCRIPTION
Closes https://github.com/sindresorhus/p-event/issues/31

Add an export of the `TimeoutError` class to be able to compare error instances, e.g.:

```javascript
import pEvent, { TimeoutError } from 'p-event';

try {
  await pEvent(emitter, 'finish');
} catch (error) {
  if (error instanceof TimeoutError) {
    // Do something specific for timeout errors
  }
}
```