### PR TITLE
Fix TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,15 +12,15 @@ export interface Emitter<EventName extends string | symbol, EmittedType extends 
 	removeEventListener?: AddRemoveListener<EventName, EmittedType>;
 }
 
-export type FilterFunction<ElementType extends unknown[]> = (
-	...arguments: ElementType
+export type FilterFunction<ElementType extends unknown | unknown[]> = (
+	value: ElementType
 ) => boolean;
 
 export interface CancelablePromise<ResolveType> extends Promise<ResolveType> {
 	cancel(): void;
 }
 
-export interface Options<EmittedType extends unknown[]> {
+export interface Options<EmittedType extends unknown | unknown[]> {
 	/**
 	Events that will reject the promise.
 
@@ -70,7 +70,7 @@ export interface MultiArgumentsOptions<EmittedType extends unknown[]>
 	readonly multiArgs: true;
 }
 
-export interface MultipleOptions<EmittedType extends unknown[]>
+export interface MultipleOptions<EmittedType extends unknown | unknown[]>
 	extends Options<EmittedType> {
 	/**
 	The number of times the event needs to be emitted before the promise resolves.
@@ -121,7 +121,7 @@ export interface MultipleMultiArgumentsOptions<EmittedType extends unknown[]>
 	readonly multiArgs: true;
 }
 
-export interface IteratorOptions<EmittedType extends unknown[]>
+export interface IteratorOptions<EmittedType extends unknown | unknown[]>
 	extends Options<EmittedType> {
 	/**
 	The maximum number of events for the iterator before it ends. When the limit is reached, the iterator will be marked as `done`. This option is useful to paginate events, for example, fetching 10 events per page.
@@ -179,12 +179,12 @@ export function pEvent<EventName extends string | symbol, EmittedType extends un
 export function pEvent<EventName extends string | symbol, EmittedType>(
 	emitter: Emitter<EventName, [EmittedType]>,
 	event: string | symbol | ReadonlyArray<string | symbol>,
-	filter: FilterFunction<[EmittedType]>
+	filter: FilterFunction<EmittedType>
 ): CancelablePromise<EmittedType>;
 export function pEvent<EventName extends string | symbol, EmittedType>(
 	emitter: Emitter<EventName, [EmittedType]>,
 	event: string | symbol | ReadonlyArray<string | symbol>,
-	options?: Options<[EmittedType]>
+	options?: Options<EmittedType>
 ): CancelablePromise<EmittedType>;
 
 /**
@@ -198,7 +198,7 @@ export function pEventMultiple<EventName extends string | symbol, EmittedType ex
 export function pEventMultiple<EventName extends string | symbol, EmittedType>(
 	emitter: Emitter<EventName, [EmittedType]>,
 	event: string | symbol | ReadonlyArray<string | symbol>,
-	options: MultipleOptions<[EmittedType]>
+	options: MultipleOptions<EmittedType>
 ): CancelablePromise<EmittedType[]>;
 
 /**
@@ -226,12 +226,12 @@ export function pEventIterator<EventName extends string | symbol, EmittedType ex
 export function pEventIterator<EventName extends string | symbol, EmittedType>(
 	emitter: Emitter<EventName, [EmittedType]>,
 	event: string | symbol | ReadonlyArray<string | symbol>,
-	filter: FilterFunction<[EmittedType]>
+	filter: FilterFunction<EmittedType>
 ): AsyncIterableIterator<EmittedType>;
 export function pEventIterator<EventName extends string | symbol, EmittedType>(
 	emitter: Emitter<EventName, [EmittedType]>,
 	event: string | symbol | ReadonlyArray<string | symbol>,
-	options?: IteratorOptions<[EmittedType]>
+	options?: IteratorOptions<EmittedType>
 ): AsyncIterableIterator<EmittedType>;
 
 export {TimeoutError} from 'p-timeout';

--- a/index.js
+++ b/index.js
@@ -40,13 +40,11 @@ const multiple = (emitter, event, options) => {
 		const {addListener, removeListener} = normalizeEmitter(emitter);
 
 		const onItem = (...args) => {
-			const value = options.multiArgs ? args : args[0];
-
-			if (options.filter && !options.filter(value)) {
+			if (options.filter && !options.filter(...args)) {
 				return;
 			}
 
-			items.push(value);
+			items.push(options.multiArgs ? args : args[0]);
 
 			if (options.count === items.length) {
 				cancel();

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ export function pEventMultiple(emitter, event, options) {
 		const onItem = (...arguments_) => {
 			const value = options.multiArgs ? arguments_ : arguments_[0];
 
-			if (options.filter && !options.filter(...arguments_)) {
+			// eslint-disable-next-line unicorn/no-array-callback-reference
+			if (options.filter && !options.filter(value)) {
 				return;
 			}
 
@@ -215,7 +216,8 @@ export function pEventIterator(emitter, event, options) {
 	const resolveHandler = (...arguments_) => {
 		const value = options.multiArgs ? arguments_ : arguments_[0];
 
-		if (options.filter && !options.filter(...arguments_)) {
+		// eslint-disable-next-line unicorn/no-array-callback-reference
+		if (options.filter && !options.filter(value)) {
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ export function pEventMultiple(emitter, event, options) {
 		const onItem = (...arguments_) => {
 			const value = options.multiArgs ? arguments_ : arguments_[0];
 
-			// eslint-disable-next-line unicorn/no-array-callback-reference
 			if (options.filter && !options.filter(...arguments_)) {
 				return;
 			}
@@ -216,7 +215,6 @@ export function pEventIterator(emitter, event, options) {
 	const resolveHandler = (...arguments_) => {
 		const value = options.multiArgs ? arguments_ : arguments_[0];
 
-		// eslint-disable-next-line unicorn/no-array-callback-reference
 		if (options.filter && !options.filter(...arguments_)) {
 			return;
 		}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -82,7 +82,7 @@ expectType<CancelablePromise<[number, string]>>(
 );
 void pEvent(new NodeEmitter(), 'finish', {
 	multiArgs: true,
-	filter: ([_, string]) => string === "🦄",
+	filter: (_, string) => string === "🦄",
 });
 
 pEvent(new NodeEmitter(), 'finish').cancel();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -81,7 +81,7 @@ expectType<CancelablePromise<[number, string]>>(
 );
 void pEvent(new NodeEmitter(), 'finish', {
 	multiArgs: true,
-	filter: (_, string) => string === "🦄",
+	filter: (_, string) => string === '🦄',
 });
 
 pEvent(new NodeEmitter(), 'finish').cancel();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -81,7 +81,7 @@ expectType<CancelablePromise<[number, string]>>(
 );
 void pEvent(new NodeEmitter(), 'finish', {
 	multiArgs: true,
-	filter: (_, string) => string === '🦄',
+	filter: ([_, string]: [number, string]) => string === '🦄',
 });
 
 pEvent(new NodeEmitter(), 'finish').cancel();
@@ -101,6 +101,11 @@ expectType<CancelablePromise<Array<[number, string]>>>(
 		multiArgs: true,
 	}),
 );
+void pEventMultiple(new NodeEmitter(), 'finish', {
+	count: Number.POSITIVE_INFINITY,
+	multiArgs: true,
+	filter: ([_, string]: [number, string]) => string === '🦄',
+});
 
 expectType<AsyncIterableIterator<number>>(
 	pEventIterator(new NodeEmitter(), 'finish'),
@@ -118,6 +123,10 @@ expectType<AsyncIterableIterator<number>>(
 expectType<AsyncIterableIterator<[number, string]>>(
 	pEventIterator(new NodeEmitter(), 'finish', {multiArgs: true}),
 );
+void pEventIterator(new NodeEmitter(), 'finish', {
+	multiArgs: true,
+	filter: ([_, string]: [number, string]) => string === '🦄',
+});
 
 async function getOpenReadStream(file: string): Promise<NodeJS.ReadableStream> {
 	const stream = fs.createReadStream(file); // eslint-disable-line @typescript-eslint/no-unsafe-assignment

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -80,6 +80,10 @@ expectType<CancelablePromise<number>>(
 expectType<CancelablePromise<[number, string]>>(
 	pEvent(new NodeEmitter(), 'finish', {multiArgs: true})
 );
+void pEvent(new NodeEmitter(), 'finish', {
+	multiArgs: true,
+	filter: ([_, string]) => string === "🦄",
+});
 
 pEvent(new NodeEmitter(), 'finish').cancel();
 


### PR DESCRIPTION
I discovered that the TypeScript definition claims that arguments are being directly reflected in the `filter` method where in reality, the method is actually being passed either the first argument alone or an array of arguments when `multiArgs === true`. I have fixed the definitions to reflect the true values.